### PR TITLE
fix: define int/float precision to prevent deprecation warning

### DIFF
--- a/.github/workflows/python-request.yml
+++ b/.github/workflows/python-request.yml
@@ -41,15 +41,20 @@ jobs:
     - name: Install dependencies for MacOS
       if: matrix.os == 'macos-latest'
       run: |
-        brew install proj
+        brew install proj@7
         brew install geos
         brew install hdf5
         brew install netcdf
         brew install eccodes
         brew install libxml2
         brew install libxslt
+        brew install pkg-config
         pip install --upgrade pip
-        pip install flake8 pytest pytest-cov numpy
+        pip install flake8 pytest pytest-cov numpy cython
+        export LDFLAGS="-L/usr/local/opt/proj@7/lib"
+        export CPPFLAGS="-I/usr/local/opt/proj@7/include"
+        export ACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/proj@7/lib/pkgconfig"
         pip install git+https://github.com/tsutterley/geoid-toolkit.git
         pip install git+https://github.com/tsutterley/read-GRACE-geocenter.git
         pip install git+https://github.com/tsutterley/read-GRACE-harmonics.git

--- a/ECCO/ecco_geoid_llc_tiles.py
+++ b/ECCO/ecco_geoid_llc_tiles.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 ecco_geoid_llc_tiles.py
-Written by Tyler Sutterley (02/2021)
+Written by Tyler Sutterley (05/2021)
 
 Calculates geoid heights for ECCO ocean model LLC tiles using model
     coefficients from the GFZ International Centre for Global Earth
@@ -41,6 +41,7 @@ PROGRAM DEPENDENCIES:
     gauss_weights.py: Computes Gaussian weights as a function of degree
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 02/2021: replaced numpy bool to prevent deprecation warning
     Written 02/2021
 """
@@ -76,9 +77,9 @@ def ecco_geoid_llc_tiles(input_file, output_file, GEOID=None,
     #-- read gravity model spherical harmonics
     Ylms = read_ICGEM_harmonics(os.path.expanduser(GEOID), LMAX=LMAX)
     #-- extract parameters
-    R = np.float(Ylms['radius'])
-    GM = np.float(Ylms['earth_gravity_constant'])
-    LMAX = np.int(Ylms['max_degree']) if not LMAX else LMAX
+    R = np.float64(Ylms['radius'])
+    GM = np.float64(Ylms['earth_gravity_constant'])
+    LMAX = np.int64(Ylms['max_degree']) if not LMAX else LMAX
     #-- dictionary with output variables
     output = {}
     #-- copy from invariant

--- a/ECCO/ecco_llc_tile_harmonics.py
+++ b/ECCO/ecco_llc_tile_harmonics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 ecco_llc_tile_harmonics.py
-Written by Tyler Sutterley (03/2021)
+Written by Tyler Sutterley (05/2021)
 Reads monthly ECCO ocean bottom pressure anomalies from LLC tiles
     and converts to spherical harmonic coefficients
 
@@ -68,6 +68,7 @@ PROGRAM DEPENDENCIES:
     utilities.py: download and management utilities for files
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 03/2021: automatically update years to run based on current time
     Written 02/2021
 """
@@ -173,7 +174,7 @@ def ecco_llc_tile_harmonics(ddir, MODEL, YEARS, LMAX=0, MMAX=None,
     #-- for each input file
     for f in sorted(FILES):
         #-- extract dates from file
-        year,month = np.array(rx.findall(f).pop(), dtype=np.int)
+        year,month = np.array(rx.findall(f).pop(), dtype=np.int64)
         #-- read input data file
         obp_data = {}
         with netCDF4.Dataset(os.path.join(input_dir,f),'r') as fileID:
@@ -240,7 +241,7 @@ def ecco_llc_tile_harmonics(ddir, MODEL, YEARS, LMAX=0, MMAX=None,
         #-- full path to output file
         full_output_file = os.path.join(ddir,output_sub,fi)
         #-- extract GRACE month
-        grace_month, = np.array(re.findall(output_regex,fi),dtype=np.int)
+        grace_month, = np.array(re.findall(output_regex,fi),dtype=np.int64)
         YY = 2002.0 + np.floor((grace_month-1)/12.0)
         MM = ((grace_month-1) % 12) + 1
         tdec, = gravity_toolkit.time.convert_calendar_decimal(YY, MM)

--- a/ECCO/ecco_mean_realtime.py
+++ b/ECCO/ecco_mean_realtime.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 ecco_mean_realtime.py
-Written by Tyler Sutterley (02/2021)
+Written by Tyler Sutterley (05/2021)
 
 Reads 12-hour ECCO ocean bottom pressure data from JPL
 Calculates multi-annual means on an equirectangular grid
@@ -53,6 +53,7 @@ REFERENCES:
         https://doi.org/10.1029/94JC00847
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 02/2021: replaced numpy bool to prevent deprecation warning
     Updated 12/2020: use argparse to set command line parameters
         using spatial module for read/write operations
@@ -109,7 +110,7 @@ def ecco_mean_realtime(ddir, MODEL, RANGE=None, DATAFORM=None,
     obp_mean = gravity_toolkit.spatial(fill_value=fill_value)
     obp_mean.lon = np.arange(dlon/2.0,360+dlon/2.0,dlon)
     obp_mean.lat = np.arange(-LAT_MAX,LAT_MAX+dlat,dlat)
-    obp_mean.data = np.zeros((158,360),dtype=np.float)
+    obp_mean.data = np.zeros((158,360),dtype=np.float64)
     obp_mean.mask = np.zeros((158,360),dtype=bool)
     obp_mean.time = 0.0
     count = 0.0

--- a/ECCO/ecco_mean_version4.py
+++ b/ECCO/ecco_mean_version4.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 ecco_mean_version4.py
-Written by Tyler Sutterley (02/2021)
+Written by Tyler Sutterley (05/2021)
 
 Calculates mean of ocean bottom pressure data from the ECCO ocean model
 https://ecco.jpl.nasa.gov/drive/files/Version4/Release4/interp_monthly/README
@@ -62,6 +62,7 @@ REFERENCES:
         https://doi.org/10.1029/94JC00847
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 02/2021: replaced numpy bool to prevent deprecation warning
     Updated 12/2020: use argparse to set command line parameters
         using spatial module for read/write operations
@@ -129,7 +130,7 @@ def ecco_mean_version4(ddir, MODEL, RANGE=None, DATAFORM=None,
 
     #-- output multi-annual mean
     obp_mean = gravity_toolkit.spatial(fill_value=fill_value)
-    obp_mean.data = np.zeros((nlat,nlon),dtype=np.float)
+    obp_mean.data = np.zeros((nlat,nlon),dtype=np.float64)
     obp_mean.mask = np.zeros((nlat,nlon),dtype=bool)
     obp_mean.time = 0.0
     #-- calculate dimension variables

--- a/ECCO/ecco_monthly_harmonics.py
+++ b/ECCO/ecco_monthly_harmonics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 ecco_monthly_harmonics.py
-Written by Tyler Sutterley (03/2021)
+Written by Tyler Sutterley (05/2021)
 Reads monthly ECCO ocean bottom pressure anomalies and converts to
     spherical harmonic coefficients
 
@@ -70,6 +70,7 @@ PROGRAM DEPENDENCIES:
     utilities.py: download and management utilities for files
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 03/2021: automatically update years to run based on current time
     Updated 02/2021: separate inputs to gen_pressure_stokes
     Updated 01/2021: added Cube92 choice to input model types
@@ -136,7 +137,7 @@ def ecco_monthly_harmonics(ddir, MODEL, YEARS, LMAX=0, MMAX=None,
         input_depth_file = os.path.join(ddir,'depth.nc')
         input_geoid_file = os.path.join(ddir,'egm_2008.nc')
         #-- indices to read
-        indices = np.arange(1,2*LAT_MAX+2).astype(np.int)
+        indices = np.arange(1,2*LAT_MAX+2).astype(np.int64)
     elif MODEL in ('Cube92',):
         #-- grid step size
         dlon,dlat = (0.25,0.25)
@@ -206,7 +207,7 @@ def ecco_monthly_harmonics(ddir, MODEL, YEARS, LMAX=0, MMAX=None,
     #-- for each input file
     for f in sorted(FILES):
         #-- extract dates from file
-        year,month = np.array(rx.findall(f).pop(), dtype=np.int)
+        year,month = np.array(rx.findall(f).pop(), dtype=np.int64)
         #-- read input data file
         if (DATAFORM == 'ascii'):
             obp_data = gravity_toolkit.spatial(spacing=[dlon,dlat],
@@ -261,7 +262,7 @@ def ecco_monthly_harmonics(ddir, MODEL, YEARS, LMAX=0, MMAX=None,
         #-- full path to output file
         full_output_file = os.path.join(ddir,output_sub,fi)
         #-- extract GRACE month
-        grace_month, = np.array(re.findall(output_regex,fi),dtype=np.int)
+        grace_month, = np.array(re.findall(output_regex,fi),dtype=np.int64)
         YY = 2002.0 + np.floor((grace_month-1)/12.0)
         MM = ((grace_month-1) % 12) + 1
         tdec, = gravity_toolkit.time.convert_calendar_decimal(YY, MM)

--- a/GLDAS/gldas_mean_monthly.py
+++ b/GLDAS/gldas_mean_monthly.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 gldas_mean_monthly.py
-Written by Tyler Sutterley (02/2021)
+Written by Tyler Sutterley (05/2021)
 
 Reads GLDAS monthly datafiles from http://ldas.gsfc.nasa.gov/gldas/
 Adding Soil Moisture, snow water equivalent (SWE) and total canopy storage
@@ -79,6 +79,7 @@ PROGRAM DEPENDENCIES:
     time.py: utilities for calculating time operations
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 02/2021: replaced numpy bool to prevent deprecation warning
     Updated 12/2020: set spatial variables for both 025 and 10 cases
         using utilities from time module
@@ -175,7 +176,7 @@ def gldas_mean_monthly(base_dir, MODEL, RANGE=None, SPATIAL=None, VERSION=None,
             #-- set the mask for valid points
             twc.mask[ii,jj,c] = False
             #-- calculate date
-            twc.time[c] = convert_calendar_decimal(np.int(YY),np.int(MM))
+            twc.time[c] = convert_calendar_decimal(np.int64(YY),np.int64(MM))
             #-- add 1 to counter
             c += 1
 

--- a/GLDAS/gldas_monthly_harmonics.py
+++ b/GLDAS/gldas_monthly_harmonics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 gldas_monthly_harmonics.py
-Written by Tyler Sutterley (03/2021)
+Written by Tyler Sutterley (05/2021)
 
 Reads monthly GLDAS total water storage anomalies and converts to
     spherical harmonic coefficients
@@ -102,6 +102,7 @@ PROGRAM DEPENDENCIES:
     utilities.py: download and management utilities for files
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 03/2021: automatically update years to run based on current time
     Updated 02/2021: include GLDAS MOD44W land mask modified for HYMAP
         replaced numpy bool to prevent deprecation warning
@@ -269,7 +270,7 @@ def gldas_monthly_harmonics(ddir, MODEL, YEARS, SPACING=None, VERSION=None,
     #-- for each input file
     for t,fi in enumerate(sorted(FILES)):
         #-- extract year and month from file
-        YY,MM = np.array(rx.findall(fi).pop(), dtype=np.float)
+        YY,MM = np.array(rx.findall(fi).pop(), dtype=np.float64)
 
         #-- read data file for data format
         if (DATAFORM == 'ascii'):
@@ -302,7 +303,7 @@ def gldas_monthly_harmonics(ddir, MODEL, YEARS, SPACING=None, VERSION=None,
         #-- calculate date information
         gldas_Ylms.time, = gravity_toolkit.time.convert_calendar_decimal(YY,MM)
         #-- calculate GRACE/GRACE-FO month
-        gldas_Ylms.month = np.int(12.0*(YY - 2002.0) + MM)
+        gldas_Ylms.month = np.int64(12.0*(YY - 2002.0) + MM)
 
         #-- output spherical harmonic data file
         args=(MODEL,SPACING,LMAX,order_str,gldas_Ylms.month,suffix[DATAFORM])
@@ -339,7 +340,7 @@ def gldas_monthly_harmonics(ddir, MODEL, YEARS, SPACING=None, VERSION=None,
         #-- full path to output file
         full_output_file = os.path.join(ddir,output_sub,fi)
         #-- extract GRACE month
-        grace_month, = np.array(re.findall(output_regex,fi),dtype=np.int)
+        grace_month, = np.array(re.findall(output_regex,fi),dtype=np.int64)
         YY = 2002.0 + np.floor((grace_month-1)/12.0)
         MM = ((grace_month-1) % 12) + 1
         tdec, = gravity_toolkit.time.convert_calendar_decimal(YY, MM)

--- a/GLDAS/gldas_read_monthly.py
+++ b/GLDAS/gldas_read_monthly.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 gldas_read_monthly.py
-Written by Tyler Sutterley (03/2021)
+Written by Tyler Sutterley (05/2021)
 
 Reads GLDAS monthly datafiles from http://ldas.gsfc.nasa.gov/gldas/
 Adding Soil Moisture, snow water equivalent (SWE) and total canopy storage
@@ -82,6 +82,7 @@ PROGRAM DEPENDENCIES:
     time.py: utilities for calculating time operations
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 03/2021: automatically update years to run based on current time
     Updated 02/2021: replaced numpy bool to prevent deprecation warning
     Updated 12/2020: set spatial variables for both 025 and 10 cases
@@ -176,7 +177,7 @@ def gldas_read_monthly(base_dir, MODEL, YEARS, RANGE=None, SPATIAL=None,
             #-- Getting date information from file
             EP,YY,MM,VF,SFX = rx.findall(fi).pop()
             #-- file output file
-            args = (MODEL, SPATIAL, np.int(YY), np.int(MM), suffix[DATAFORM])
+            args = (MODEL, SPATIAL, np.int64(YY), np.int64(MM), suffix[DATAFORM])
             FILE = 'GLDAS_{0}{1}_TWC_{2:4d}_{3:02d}.{4}'.format(*args)
             TEST = False
             #-- Checking if output file exists
@@ -217,7 +218,7 @@ def gldas_read_monthly(base_dir, MODEL, YEARS, RANGE=None, SPATIAL=None,
                 twc.mask[ii,jj] = False
                 #-- calculate date
                 twc.time = gravity_toolkit.time.convert_calendar_decimal(
-                    np.int(YY),np.int(MM))
+                    np.int64(YY),np.int64(MM))
 
                 #-- output to file
                 if (DATAFORM == 'ascii'):

--- a/SMB/merra_smb_harmonics.py
+++ b/SMB/merra_smb_harmonics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 merra_smb_harmonics.py
-Written by Tyler Sutterley (03/2021)
+Written by Tyler Sutterley (05/2021)
 Reads monthly MERRA-2 surface mass balance anomalies and
     converts to spherical harmonic coefficients
 
@@ -65,6 +65,7 @@ PROGRAM DEPENDENCIES:
     utilities.py: download and management utilities for files
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 03/2021: automatically update years to run based on current time
     Updated 02/2021: can use multiple mask files to create a combined solution
         replaced numpy bool to prevent deprecation warning
@@ -207,7 +208,7 @@ def merra_smb_harmonics(ddir, PRODUCT, YEARS, RANGE=None, REGION=None,
         #-- copy date information
         merra_Ylms.time = np.copy(merra_data.time)
         #-- calculate GRACE/GRACE-FO month
-        merra_Ylms.month = np.int(12.0*(np.float(Y1) - 2002.0) + np.float(M1))
+        merra_Ylms.month = np.int64(12.0*(np.float64(Y1) - 2002.0) + np.float64(M1))
         #-- output spherical harmonic data file
         args=(MOD,PRODUCT,LMAX,order_str,merra_Ylms.month,suffix[DATAFORM])
         FILE='MERRA2_{0}_tavgM_2d_{1}_CLM_L{2:d}{3}_{4:03d}.{5}'.format(*args)
@@ -245,7 +246,7 @@ def merra_smb_harmonics(ddir, PRODUCT, YEARS, RANGE=None, REGION=None,
         #-- full path to output file
         full_output_file = os.path.join(ddir,output_sub,fi)
         #-- extract GRACE month
-        MOD,grace_month=np.array(re.findall(output_regex,fi).pop(),dtype=np.int)
+        MOD,grace_month=np.array(re.findall(output_regex,fi).pop(),dtype=np.int64)
         YY = 2002.0 + np.floor((grace_month-1)/12.0)
         MM = ((grace_month-1) % 12) + 1
         tdec, = gravity_toolkit.time.convert_calendar_decimal(YY, MM)

--- a/model_harmonics/gen_atmosphere_stokes.py
+++ b/model_harmonics/gen_atmosphere_stokes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 gen_atmosphere_stokes.py
-Written by Tyler Sutterley (01/2021)
+Written by Tyler Sutterley (05/2021)
 Calculates spherical harmonic fields from 3D atmospheric geopotential
     height and pressure difference fields
 
@@ -63,6 +63,7 @@ REFERENCE:
     76: 279-299, 2002. https://doi.org/10.1007/s00190-002-0216-2
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 01/2021: added function docstrings
     Updated 05/2020: use harmonics class for spherical harmonic operations
     Updated 04/2020: made Legendre polynomials and Love numbers options
@@ -114,7 +115,7 @@ def gen_atmosphere_stokes(GPH, pressure, lon, lat, LMAX=0, MMAX=None,
     """
 
     #-- converting LMAX to integer
-    LMAX = np.int(LMAX)
+    LMAX = np.int64(LMAX)
     #-- upper bound of spherical harmonic orders (default = LMAX)
     MMAX = np.copy(LMAX) if not MMAX else MMAX
 

--- a/model_harmonics/gen_pressure_stokes.py
+++ b/model_harmonics/gen_pressure_stokes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 gen_pressure_stokes.py
-Written by Tyler Sutterley (02/2021)
+Written by Tyler Sutterley (05/2021)
 Calculates spherical harmonic fields from spatial pressure fields
 
 CALLING SEQUENCE:
@@ -57,6 +57,7 @@ REFERENCE:
     76: 279-299, 2002. https://doi.org/10.1007/s00190-002-0216-2
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 02/2021: separate pressure and gravitational acceleration inputs
     Updated 01/2021: use harmonics class for spherical harmonic operations
     Updated 07/2020: added function docstrings
@@ -104,12 +105,12 @@ def gen_pressure_stokes(P, G, R, lon, lat, LMAX=60, MMAX=None,
     """
 
     #-- converting LMAX to integer
-    LMAX = np.int(LMAX)
+    LMAX = np.int64(LMAX)
     #-- upper bound of spherical harmonic orders (default = LMAX)
     MMAX = np.copy(LMAX) if not MMAX else MMAX
 
     #-- grid dimensions
-    nlat = np.int(len(lat))
+    nlat = np.int64(len(lat))
     #-- grid step
     dlon = np.abs(lon[1]-lon[0])
     dlat = np.abs(lat[1]-lat[0])

--- a/reanalysis/reanalysis_atmospheric_harmonics.py
+++ b/reanalysis/reanalysis_atmospheric_harmonics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 reanalysis_atmospheric_harmonics.py
-Written by Tyler Sutterley (03/2021)
+Written by Tyler Sutterley (05/2021)
 Reads atmospheric geopotential heights fields from reanalysis and calculates
     sets of spherical harmonics using a 3D geometry
 
@@ -72,6 +72,7 @@ REFERENCES:
         https://doi.org/10.1029/2000JB000024
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 03/2021: automatically update years to run based on current time
     Updated 01/2021: read from netCDF4 file in slices to reduce memory load
         separated gen_atmosphere_stokes to a separate function
@@ -299,7 +300,7 @@ def reanalysis_atmospheric_harmonics(base_dir, MODEL, YEARS, RANGE=None,
             Ylms.time,=gravity_toolkit.time.convert_calendar_decimal(YY,
                 MM, day=DD, hour=hh, minute=mm, second=ss)
             #-- calculate GRACE month from calendar dates
-            Ylms.month, = np.array([(YY - 2002)*12 + MM], dtype=np.int)
+            Ylms.month, = np.array([(YY - 2002)*12 + MM], dtype=np.int64)
             #-- output data to file
             args = (MODEL.upper(),LMAX,order_str,Ylms.month,suffix[DATAFORM])
             FILE = output_file_format.format(*args)
@@ -329,7 +330,7 @@ def reanalysis_atmospheric_harmonics(base_dir, MODEL, YEARS, RANGE=None,
         #-- full path to output file
         full_output_file = os.path.join(ddir,output_sub,fi)
         #-- extract GRACE month
-        grace_month, = np.array(re.findall(output_regex,fi),dtype=np.int)
+        grace_month, = np.array(re.findall(output_regex,fi),dtype=np.int64)
         YY = 2002.0 + np.floor((grace_month-1)/12.0)
         MM = ((grace_month-1) % 12) + 1
         tdec, = gravity_toolkit.time.convert_calendar_decimal(YY, MM)
@@ -350,7 +351,7 @@ def reanalysis_atmospheric_harmonics(base_dir, MODEL, YEARS, RANGE=None,
 def ncdf_geoid(FILENAME):
     with netCDF4.Dataset(FILENAME,'r') as fileID:
         geoid_undulation = fileID.variables['geoid'][:].copy()
-        gridstep = np.array(fileID.gridstep.split(','),dtype=np.float)
+        gridstep = np.array(fileID.gridstep.split(','),dtype=np.float64)
     return (geoid_undulation,np.squeeze(gridstep))
 
 #-- PURPOSE: read land sea mask to get indices of oceanic values

--- a/reanalysis/reanalysis_geopotential_heights.py
+++ b/reanalysis/reanalysis_geopotential_heights.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 reanalysis_geopotential_heights.py
-Written by Tyler Sutterley (03/2021)
+Written by Tyler Sutterley (05/2021)
 Reads temperature and specific humidity data to calculate geopotential height
     and pressure difference fields at half levels from reanalysis
 
@@ -25,6 +25,7 @@ PYTHON DEPENDENCIES:
         https://unidata.github.io/netcdf4-python/netCDF4/index.html
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 03/2021: automatically update years to run based on current time
     Updated 01/2021: read from netCDF4 file in slices to reduce memory load
     Updated 12/2020: using argparse to set command line options
@@ -166,14 +167,14 @@ def reanalysis_geopotential_heights(base_dir, MODEL, YEAR=None,
 
         if MODEL in ('MERRA-2'):
             #-- extract date from monthly files
-            MOD,YEAR,MONTH = np.array(rx.findall(fi).pop(), dtype=np.float)
+            MOD,YEAR,MONTH = np.array(rx.findall(fi).pop(), dtype=np.float64)
             #-- output monthly filename
             FILE = os.path.join(ddir,output_file_format.format(MOD,YEAR,MONTH))
             #-- read surface pressure
             surface_pressure = np.copy(fid1.variables[VARNAME][:])
         elif MODEL in ('ERA-Interim','ERA5'):
             #-- extract year from file name
-            YEAR, = np.array(rx.findall(fi),dtype=np.int)
+            YEAR, = np.array(rx.findall(fi),dtype=np.int64)
             #-- output yearly filename
             FILE = os.path.join(ddir,output_file_format.format(YEAR))
             #-- read input surface pressure data

--- a/reanalysis/reanalysis_mean_harmonics.py
+++ b/reanalysis/reanalysis_mean_harmonics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 reanalysis_mean_harmonics.py
-Written by Tyler Sutterley (01/2021)
+Written by Tyler Sutterley (05/2021)
 Reads atmospheric geopotential heights fields from reanalysis and calculates
     a multi-annual mean set of spherical harmonics using a 3D geometry
 
@@ -71,6 +71,7 @@ REFERENCES:
         https://doi.org/10.1029/2000JB000024
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 01/2021: read from netCDF4 file in slices to reduce memory load
         separated gen_atmosphere_stokes to a separate function
     Updated 12/2020: using argparse to set command line options
@@ -267,7 +268,7 @@ def reanalysis_mean_harmonics(base_dir, MODEL, RANGE=None, REDISTRIBUTE=False,
             Ylms.time, = gravity_toolkit.time.convert_calendar_decimal(YY,
                 MM, day=DD, hour=hh, minute=mm, second=ss)
             #-- calculate GRACE month from calendar dates
-            Ylms.month, = np.array([(YY - 2002)*12 + MM], dtype=np.int)
+            Ylms.month, = np.array([(YY - 2002)*12 + MM], dtype=np.int64)
             #-- append to list of harmonics
             harmonics_list.append(Ylms)
         #-- close the input netCDF4 file
@@ -296,7 +297,7 @@ def reanalysis_mean_harmonics(base_dir, MODEL, RANGE=None, REDISTRIBUTE=False,
 def ncdf_geoid(FILENAME):
     with netCDF4.Dataset(FILENAME,'r') as fileID:
         geoid_undulation = fileID.variables['geoid'][:].copy()
-        gridstep = np.array(fileID.gridstep.split(','),dtype=np.float)
+        gridstep = np.array(fileID.gridstep.split(','),dtype=np.float64)
     return (geoid_undulation,np.squeeze(gridstep))
 
 #-- PURPOSE: read land sea mask to get indices of oceanic values

--- a/reanalysis/reanalysis_mean_pressure.py
+++ b/reanalysis/reanalysis_mean_pressure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 reanalysis_mean_pressure.py
-Written by Tyler Sutterley (02/2021)
+Written by Tyler Sutterley (05/2021)
 Calculates the mean surface pressure fields from reanalysis
 
 INPUTS:
@@ -50,6 +50,7 @@ REFERENCES:
         https://doi.org/10.1029/2000JB000024
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 02/2021: replaced numpy bool to prevent deprecation warning
     Updated 12/2020: using argparse to set command line options
         using time module for operations and for extracting time units
@@ -194,7 +195,7 @@ def reanalysis_mean_pressure(base_dir, MODEL, RANGE=None,
     indy,indx = np.nonzero(~p_mean.mask)
     p_mean.data[indy,indx] /= count
     p_mean.update_mask()
-    p_mean.time /= np.float(count)
+    p_mean.time /= np.float64(count)
 
     #-- output to file
     FILE = output_file_format.format(RANGE[0], RANGE[1])

--- a/reanalysis/reanalysis_monthly_harmonics.py
+++ b/reanalysis/reanalysis_monthly_harmonics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 reanalysis_monthly_harmonics.py
-Written by Tyler Sutterley (03/2021)
+Written by Tyler Sutterley (05/2021)
 Reads atmospheric surface pressure fields from reanalysis and calculates sets of
     spherical harmonics using a thin-layer 2D spherical geometry
 
@@ -74,6 +74,7 @@ REFERENCES:
         https://doi.org/10.1029/2000JB000024
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 03/2021: automatically update years to run based on current time
     Updated 01/2021: harmonics object output from gen_stokes.py
     Updated 12/2020: using argparse to set command line options
@@ -308,7 +309,7 @@ def reanalysis_monthly_harmonics(base_dir, MODEL, YEARS, RANGE=None,
             Ylms.time,=gravity_toolkit.time.convert_calendar_decimal(YY,
                 MM, day=DD, hour=hh, minute=mm, second=ss)
             #-- calculate GRACE month from calendar dates
-            Ylms.month, = np.array([(YY - 2002)*12 + MM], dtype=np.int)
+            Ylms.month, = np.array([(YY - 2002)*12 + MM], dtype=np.int64)
             #-- output data to file
             args = (MODEL.upper(),LMAX,order_str,Ylms.month,suffix[DATAFORM])
             FILE = output_file_format.format(*args)
@@ -336,7 +337,7 @@ def reanalysis_monthly_harmonics(base_dir, MODEL, YEARS, RANGE=None,
         #-- full path to output file
         full_output_file = os.path.join(ddir,output_sub,fi)
         #-- extract GRACE month
-        grace_month, = np.array(re.findall(output_regex,fi),dtype=np.int)
+        grace_month, = np.array(re.findall(output_regex,fi),dtype=np.int64)
         YY = 2002.0 + np.floor((grace_month-1)/12.0)
         MM = ((grace_month-1) % 12) + 1
         tdec, = gravity_toolkit.time.convert_calendar_decimal(YY, MM)

--- a/reanalysis/reanalysis_monthly_pressure.py
+++ b/reanalysis/reanalysis_monthly_pressure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 calculate_monthly_pressure.py
-Written by Tyler Sutterley (03/2021)
+Written by Tyler Sutterley (05/2021)
 Reads daily atmospheric pressure fields from reanalysis and outputs monthly averages
 
 INPUTS:
@@ -34,6 +34,7 @@ PROGRAM DEPENDENCIES:
     time.py: utilities for calculating time operations
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 03/2021: automatically update years to run based on current time
     Updated 12/2020: using argparse to set command line options
         using spatial module for operations
@@ -91,7 +92,7 @@ def reanalysis_monthly_pressure(base_dir,MODEL,YEARS,VERBOSE=False,MODE=0o775):
                 #-- for each day in the month
                 indices = np.arange(cumulative_days[m],cumulative_days[m+1])
                 try:
-                    p_mean.append(p.mean(indices=indices.astype(np.int)))
+                    p_mean.append(p.mean(indices=indices.astype(np.int64)))
                 except:
                     break
                 else:

--- a/reanalysis/reanalysis_pressure_harmonics.py
+++ b/reanalysis/reanalysis_pressure_harmonics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 reanalysis_pressure_harmonics.py
-Written by Tyler Sutterley (03/2021)
+Written by Tyler Sutterley (05/2021)
 Reads atmospheric surface pressure fields from reanalysis and calculates sets of
     spherical harmonics using a thin-layer 2D geometry with realistic earth
 
@@ -75,6 +75,7 @@ REFERENCES:
         https://doi.org/10.1029/2000JB000024
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 03/2021: automatically update years to run based on current time
     Updated 02/2021: separate inputs to gen_pressure_stokes
     Updated 01/2021: outputs from gen_pressure_stokes are now harmonics objects
@@ -366,7 +367,7 @@ def reanalysis_pressure_harmonics(base_dir, MODEL, YEARS, RANGE=None,
             Ylms.time,=gravity_toolkit.time.convert_calendar_decimal(YY,
                 MM, day=DD, hour=hh, minute=mm, second=ss)
             #-- calculate GRACE month from calendar dates
-            Ylms.month, = np.array([(YY - 2002)*12 + MM], dtype=np.int)
+            Ylms.month, = np.array([(YY - 2002)*12 + MM], dtype=np.int64)
             #-- output data to file
             args = (MODEL.upper(),LMAX,order_str,Ylms.month,suffix[DATAFORM])
             FILE = output_file_format.format(*args)
@@ -394,7 +395,7 @@ def reanalysis_pressure_harmonics(base_dir, MODEL, YEARS, RANGE=None,
         #-- full path to output file
         full_output_file = os.path.join(ddir,output_sub,fi)
         #-- extract GRACE month
-        grace_month, = np.array(re.findall(output_regex,fi),dtype=np.int)
+        grace_month, = np.array(re.findall(output_regex,fi),dtype=np.int64)
         YY = 2002.0 + np.floor((grace_month-1)/12.0)
         MM = ((grace_month-1) % 12) + 1
         tdec, = gravity_toolkit.time.convert_calendar_decimal(YY, MM)
@@ -429,7 +430,7 @@ def ncdf_invariant(FILENAME,ZNAME):
 def ncdf_geoid(FILENAME):
     with netCDF4.Dataset(FILENAME,'r') as fileID:
         geoid_undulation = fileID.variables['geoid'][:].copy()
-        gridstep = np.array(fileID.gridstep.split(','),dtype=np.float)
+        gridstep = np.array(fileID.gridstep.split(','),dtype=np.float64)
     return (geoid_undulation,np.squeeze(gridstep))
 
 #-- PURPOSE: read land sea mask to get indices of oceanic values

--- a/reanalysis/ucar_rda_cfsr_surface.py
+++ b/reanalysis/ucar_rda_cfsr_surface.py
@@ -59,6 +59,7 @@ PROGRAM DEPENDENCIES:
 UPDATE HISTORY:
     Updated 05/2021: added option for connection timeout (in seconds)
         use try/except for retrieving netrc credentials
+        define int/float precision to prevent deprecation warning
     Updated 04/2021: set a default netrc file and check access
         default credentials from environmental variables
     Updated 02/2021: replaced numpy bool to prevent deprecation warning
@@ -135,7 +136,7 @@ def ucar_rda_download(links_list_file, DIRECTORY=None, YEARS=None,
     nlat,nlon = (361,720)
 
     #-- for each unique date
-    YEARS = np.unique(year).astype(np.float) if (YEARS is None) else YEARS
+    YEARS = np.unique(year).astype(np.float64) if (YEARS is None) else YEARS
     for YY in YEARS:
         #-- compile regular expression operators for finding files in year
         rx = re.compile(regex_pattern.format(prefix,str(YY),suffix), re.VERBOSE)
@@ -178,7 +179,7 @@ def ucar_rda_download(links_list_file, DIRECTORY=None, YEARS=None,
             #-- for each month
             for tt,mn in enumerate(M):
                 #-- convert month number to variable indice
-                m1 = np.int(mn - 1)
+                m1 = np.int64(mn - 1)
                 #-- extract data for the month
                 p_month[m1].append(dinput.index(tt))
 

--- a/reanalysis/ucar_rda_jra55_surface.py
+++ b/reanalysis/ucar_rda_jra55_surface.py
@@ -59,6 +59,7 @@ PROGRAM DEPENDENCIES:
 UPDATE HISTORY:
     Updated 05/2021: added option for connection timeout (in seconds)
         use try/except for retrieving netrc credentials
+        define int/float precision to prevent deprecation warning
     Updated 04/2021: set a default netrc file and check access
         default credentials from environmental variables
     Updated 02/2021: replaced numpy bool to prevent deprecation warning
@@ -162,7 +163,7 @@ def ucar_rda_download(links_list_file, DIRECTORY=None, YEARS=None,
     nlat,nlon = (145,288) if INTERPOLATED else (320,640)
     var = 0 if INTERPOLATED else 4
     #-- for each unique date
-    YEARS = np.unique(year).astype(np.int) if (YEARS is None) else YEARS
+    YEARS = np.unique(year).astype(np.int64) if (YEARS is None) else YEARS
     for YY in YEARS:
         #-- compile regular expression operators
         rx = re.compile(regex_pattern.format(prefix,str(YY),suffix), re.VERBOSE)
@@ -210,7 +211,7 @@ def ucar_rda_download(links_list_file, DIRECTORY=None, YEARS=None,
             #-- for each month
             for tt,mn in enumerate(M):
                 #-- convert month number to variable indice
-                m1 = np.int(mn - 1)
+                m1 = np.int64(mn - 1)
                 #-- extract data for the month
                 p_month[m1].append(dinput.index(tt))
 

--- a/scripts/least_squares_mascon_timeseries.py
+++ b/scripts/least_squares_mascon_timeseries.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 least_squares_mascon_timeseries.py
-Written by Tyler Sutterley (04/2021)
+Written by Tyler Sutterley (05/2021)
 
 Calculates a time-series of regional mass anomalies through a
     least-squares mascon procedure procedure from an index of
@@ -110,6 +110,7 @@ REFERENCES:
         https://doi.org/10.1029/2009GL039401
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 04/2021: add parser object for removing commented or empty lines
     Updated 02/2021: changed remove index to files with specified formats
     Updated 01/2021: harmonics object output from gen_stokes.py/ocean_stokes.py
@@ -248,19 +249,19 @@ def least_squares_mascons(parameters, LOVE_NUMBERS=0, REFERENCE=None,
     INDEX_FILE = os.path.expanduser(parameters['INDEX_FILE'])
     DATAFORM = parameters['DATAFORM']
     #-- Date Range and missing months
-    start_mon = np.int(parameters['START'])
-    end_mon = np.int(parameters['END'])
-    missing = np.array(parameters['MISSING'].split(','),dtype=np.int)
+    start_mon = np.int64(parameters['START'])
+    end_mon = np.int64(parameters['END'])
+    missing = np.array(parameters['MISSING'].split(','),dtype=np.int64)
     #-- spherical harmonic degree range
-    LMIN = np.int(parameters['LMIN'])
-    LMAX = np.int(parameters['LMAX'])
+    LMIN = np.int64(parameters['LMIN'])
+    LMAX = np.int64(parameters['LMAX'])
     #-- maximum spherical harmonic order
     if (parameters['MMAX'].title() == 'None'):
         MMAX = np.copy(LMAX)
     else:
-        MMAX = np.int(parameters['MMAX'])
+        MMAX = np.int64(parameters['MMAX'])
     #-- gaussian smoothing radius
-    RAD = np.float(parameters['RAD'])
+    RAD = np.float64(parameters['RAD'])
     #-- filter coefficients for stripe effects
     DESTRIPE = parameters['DESTRIPE'] in ('Y','y')
     #-- index of mascons spherical harmonics
@@ -275,7 +276,7 @@ def least_squares_mascons(parameters, LOVE_NUMBERS=0, REFERENCE=None,
     #-- output directory
     DIRECTORY = os.path.expanduser(parameters['DIRECTORY'])
     #-- 1: fit mass, 2: fit geoid
-    FIT_METHOD = np.int(parameters['FIT_METHOD'])
+    FIT_METHOD = np.int64(parameters['FIT_METHOD'])
 
     #-- Recursively create output directory if not currently existing
     if (not os.access(DIRECTORY,os.F_OK)):
@@ -451,7 +452,7 @@ def least_squares_mascons(parameters, LOVE_NUMBERS=0, REFERENCE=None,
 
     #-- Calculating the number of cos and sin harmonics between LMIN and LMAX
     #-- taking into account MMAX (if MMAX == LMAX then LMAX-MMAX=0)
-    n_harm=np.int(LMAX**2 - LMIN**2 + 2*LMAX + 1 - (LMAX-MMAX)**2 - (LMAX-MMAX))
+    n_harm=np.int64(LMAX**2 - LMIN**2 + 2*LMAX + 1 - (LMAX-MMAX)**2 - (LMAX-MMAX))
 
     #-- Initialing harmonics for least squares fitting
     #-- mascon kernel

--- a/scripts/least_squares_mascons.py
+++ b/scripts/least_squares_mascons.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 least_squares_mascons.py
-Written by Tyler Sutterley (04/2021)
+Written by Tyler Sutterley (05/2021)
 
 Calculates regional mass anomalies through a least-squares mascon procedure
     from an index of spherical harmonic coefficient files
@@ -104,6 +104,7 @@ REFERENCES:
         https://doi.org/10.1029/2009GL039401
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 04/2021: add parser object for removing commented or empty lines
     Updated 01/2021: harmonics object output from gen_stokes.py/ocean_stokes.py
     Updated 12/2020: added more love number options
@@ -243,15 +244,15 @@ def least_squares_mascons(parameters, LOVE_NUMBERS=0, REFERENCE=None,
     INDEX_FILE = os.path.expanduser(parameters['INDEX_FILE'])
     DATAFORM = parameters['DATAFORM']
     #-- spherical harmonic degree range
-    LMIN = np.int(parameters['LMIN'])
-    LMAX = np.int(parameters['LMAX'])
+    LMIN = np.int64(parameters['LMIN'])
+    LMAX = np.int64(parameters['LMAX'])
     #-- maximum spherical harmonic order
     if (parameters['MMAX'].title() == 'None'):
         MMAX = np.copy(LMAX)
     else:
-        MMAX = np.int(parameters['MMAX'])
+        MMAX = np.int64(parameters['MMAX'])
     #-- gaussian smoothing radius
-    RAD = np.float(parameters['RAD'])
+    RAD = np.float64(parameters['RAD'])
     #-- filter coefficients for stripe effects
     DESTRIPE = parameters['DESTRIPE'] in ('Y','y')
     #-- index of mascons spherical harmonics
@@ -267,7 +268,7 @@ def least_squares_mascons(parameters, LOVE_NUMBERS=0, REFERENCE=None,
     #-- output directory
     DIRECTORY = os.path.expanduser(parameters['DIRECTORY'])
     #-- 1: fit mass, 2: fit geoid
-    FIT_METHOD = np.int(parameters['FIT_METHOD'])
+    FIT_METHOD = np.int64(parameters['FIT_METHOD'])
 
     #-- Recursively create output directory if not currently existing
     if (not os.access(DIRECTORY,os.F_OK)):
@@ -391,7 +392,7 @@ def least_squares_mascons(parameters, LOVE_NUMBERS=0, REFERENCE=None,
 
     #-- Calculating the number of cos and sin harmonics between LMIN and LMAX
     #-- taking into account MMAX (if MMAX == LMAX then LMAX-MMAX=0)
-    n_harm=np.int(LMAX**2 - LMIN**2 + 2*LMAX + 1 - (LMAX-MMAX)**2 - (LMAX-MMAX))
+    n_harm=np.int64(LMAX**2 - LMIN**2 + 2*LMAX + 1 - (LMAX-MMAX)**2 - (LMAX-MMAX))
 
     #-- Initialing harmonics for least squares fitting
     #-- mascon kernel

--- a/scripts/spatial_operators.py
+++ b/scripts/spatial_operators.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 spatial_operators.py
-Written by Tyler Sutterley (02/2021)
+Written by Tyler Sutterley (05/2021)
 Performs basic operations on spatial files
 
 CALLING SEQUENCE:
@@ -52,6 +52,7 @@ PROGRAM DEPENDENCIES:
         hdf5_write.py: writes output spatial data to HDF5
 
 UPDATE HISTORY:
+    Updated 05/2021: define int/float precision to prevent deprecation warning
     Updated 02/2021: added variance off mean as estimated error
         add options to read from individual index files
     Written 02/2021
@@ -83,11 +84,11 @@ def spatial_operators(INPUT_FILES, OUTPUT_FILE, OPERATION=None, DDEG=None,
     dlon,dlat = (DDEG,DDEG) if (np.ndim(DDEG) == 0) else (DDEG[0],DDEG[1])
     #-- Grid dimensions
     if (INTERVAL == 1):#-- (0:360, 90:-90)
-        nlon = np.int((360.0/dlon)+1.0)
-        nlat = np.int((180.0/dlat)+1.0)
+        nlon = np.int64((360.0/dlon)+1.0)
+        nlat = np.int64((180.0/dlat)+1.0)
     elif (INTERVAL == 2):#-- degree spacing/2
-        nlon = np.int((360.0/dlon))
-        nlat = np.int((180.0/dlat))
+        nlon = np.int64((360.0/dlon))
+        nlat = np.int64((180.0/dlat))
 
     #-- read each input file
     dinput = [None]*n_files


### PR DESCRIPTION
ci: pin proj to v7 for cartopy install

* homebrew now installs proj8 by default
* proj8 deprecated and removed the `proj_api.h` header